### PR TITLE
Simulate a user command error

### DIFF
--- a/lib/CommandCenter/index.js
+++ b/lib/CommandCenter/index.js
@@ -11,6 +11,7 @@ function CommandCenter(eventManager) {
 	this.commandSystemStarted = false;
 	this.cmdMode = 'free';
 	this.simulatedTransportError = null;
+	this.simulatedCommandError = null;
 
 	this.eventManager = eventManager;
 }
@@ -101,6 +102,13 @@ CommandCenter.prototype.simulateTransportError = function (type) {
 	this.simulatedTransportError = type;
 };
 
+CommandCenter.prototype.simulateCommandError = function (cmdName, error) {
+	this.simulatedCommandError = {
+		cmdName: cmdName,
+		error: error
+	};
+};
+
 CommandCenter.prototype.setupCommandSystem = function (config) {
 	if (this.commandSystemStarted) {
 		return;
@@ -183,6 +191,13 @@ CommandCenter.prototype.setupCommandSystem = function (config) {
 			var errorCode = response[0];
 			var cmdResponse = response[1];
 			var events = response[2];
+
+			if (that.simulatedCommandError && that.simulatedCommandError.cmdName === cmd.name) {
+				errorCode = that.simulatedCommandError.error;
+				cmdResponse = null;
+				events = null;
+				that.simulatedCommandError = null;
+			}
 
 			if (events) {
 				that.eventManager.emitEvents(events);


### PR DESCRIPTION
This allows a user to simulate a command error (although the command does get executed). This eases testability of error handling on user command failure.