### PR TITLE
Pass options in the expected format to HttpRequest

### DIFF
--- a/lib/CommandCenter/index.js
+++ b/lib/CommandCenter/index.js
@@ -29,7 +29,10 @@ CommandCenter.prototype.createTransport = function (type, options) {
 		throw new Error('No transport type "' + type + '" found.');
 	}
 
-	return new Transport(options);
+	return new Transport({
+		noCache: true,
+		withCredentials: options && options.cors && options.cors.credentials ? true : false
+	});
 };
 
 // command center


### PR DESCRIPTION
This changes the CommandCenter to create the transport https://github.com/mage/mage-sdk-js/blob/master/lib/messageStream/http.js#L11-L14

The current behavior was erroneous since `httpOptions` is not currently set (see related PR in the MAGE repo) and prevented CORS to work properly with cookies and basic auth